### PR TITLE
rust: fix library build inside cargo command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -211,7 +211,7 @@ clean: fake
 	rm -rf $(BINS) config.h $(OBJS) $(ARM64_OBJS) $(X86_64_OBJS) $(WASM_OBJS) target
 
 distclean: clean
-	rm -rf $(ARS) deps target
+	rm -rf $(ARS) liblnsocket.a deps target
 
 
 .PHONY: fake


### PR DESCRIPTION
Updates to build lnsocket library through cargo and archive it in a rust package.

Tested on https://github.com/lvaccaro/btctipserver/blob/62aaddac37b0a7ee4a18d6e90e7276e2f6351440/Cargo.toml#L31
